### PR TITLE
fix syntax error: unexpected end of file when running full-snailycad-…

### DIFF
--- a/full-snailycad-recovery.sh
+++ b/full-snailycad-recovery.sh
@@ -165,7 +165,7 @@ show_menu() {
     echo "1. List all users"
     echo "2. Unlink Discord ID"
     echo "3. Update CAD whitelist (disable all)"
-    echo "4. (i.e., re-enable login via username and password, and disable Discord forced authentication).
+    echo "4. (i.e., re-enable login via username and password, and disable Discord forced authentication)."
     echo "5. Reset a user's password"
     echo "6. Run maintenance commands"
     echo "0. Exit"


### PR DESCRIPTION
…recovery.sh

missed " causing a syntax error and the file not to run